### PR TITLE
Serve Static Files with FastAPI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,7 @@
-from fastapi import FastAPI, HTTPResponse
-from pydantic import SqlAlchemy
-from sqlalchemy .database import engine, Session
-from sqlalchemy .models import TodoItem
-from sqlalchemy .init_db import init_db 
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 
-@app.get("/")
-def read_todos():
-    with Session(bind=engine) as session:
-        return session.query(TodoItem).all()
+# Serve static files from the root path
+app.mount("/", StaticFiles(directory="static", html=True), name="static")


### PR DESCRIPTION
This update modifies the FastAPI application to serve static files, enabling the backend to serve the frontend directly. This simplifies the application structure by allowing both the frontend and backend to be hosted together.